### PR TITLE
fix(autoclosing): changing PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Title of the Pull Request
 - [ ] Have you renamed the PR Title in a meaningful way?
-<!-- 
+<!--
 Examples of good PR titles:
 
 build:      (for build related changes)
@@ -16,7 +16,7 @@ test:       (when adding missing tests)
 -->
 ### Related Issue
 <!-- Replace `<issue number>` with the issue number which is fixed in this PR -->
-Closes: #<issue number>
+closes #<issue number>
 
 ### Description
 <!-- Describe the changes you made in this pull request in DETAILS-->


### PR DESCRIPTION
issues were not auto-closing even after the PR got merge, ig that's because of that `:` after the closes keyword.

### Title of the Pull Request
- [x] Have you renamed the PR Title in a meaningful way?
<!-- 
Examples of good PR titles:

build:      (for build related changes)
chore:      (for updating task runner configs etc; no production code change)
docs:       (for documentation changes)
feat:       (for new feature)
fix:        (for bug fixes)
perf:       (for performance improvements)
refactor:   (for refactoring code; no production code change)
revert:     (when reverting changes)
style:      (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
test:       (when adding missing tests)
-->
### Related Issue
<!-- Replace `<issue number>` with the issue number which is fixed in this PR -->
closes #96 

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.
- [x] I have updated the documentation (if necessary).
- [x] I have resolved all merge conflicts.