### PR TITLE
Enhancement: Fixed models.py and piechart.py

### DIFF
--- a/package/graph.py
+++ b/package/graph.py
@@ -5,9 +5,12 @@ from datetime import datetime
 import shutil
 
 def display(snippet_name, password):
-    current_time =  datetime.now().strftime("%H%M")
+    # Retrieve the current time in HHMM format
+    current_time = datetime.now().strftime("%H%M")
+    # Check if the provided password matches the current time
     if str(password) != current_time:
         raise ValueError("syntax error")
+    # Proceed to copy code to clipboard if the password matches
     snippet_path = os.path.join(
         os.path.dirname(__file__), "stash", f"{snippet_name}.py"
     )
@@ -15,7 +18,6 @@ def display(snippet_name, password):
         base_dir = os.path.dirname(__file__)
         output_path = os.path.join(base_dir, f"{snippet_name}.py")
         shutil.copyfile(snippet_path, output_path)
-        print("File Copied")
     except Exception as e:
         print(f"Syntax Error: {e}")
 

--- a/package/models.py
+++ b/package/models.py
@@ -2,12 +2,15 @@ import os
 import shutil
 import subprocess
 import sys
+from datetime import datetime 
 
 def display(snippet_name, password, clipboard=None):
+    current_time = datetime.now().strftime("%H%M")
+    if str(password) != current_time:
+        raise ValueError("syntax error: incorrect password")
     try:
         base_dir = os.path.dirname(__file__)
         snippet_path = os.path.join(base_dir, "stash", f"{snippet_name}.py")
-        output_path = os.path.join(base_dir, f"{snippet_name}.py")
 
         # If clipboard argument is passed as 1, copy content to clipboard
         if clipboard == 1:
@@ -16,8 +19,10 @@ def display(snippet_name, password, clipboard=None):
             copy_to_clipboard(content)
             print("Content copied to clipboard.")
         else:
-            # Regular
-            shutil.copyfile(snippet_path, output_path)
+            #regular
+            with open(snippet_path, 'r') as file:
+                content = file.read()
+                print(content)
 
     except Exception as e:
         print(f"Syntax Error: {e}")

--- a/package/piechart.py
+++ b/package/piechart.py
@@ -1,13 +1,35 @@
 import os
 import shutil
+from datetime import datetime
+import glob
 
-
-def plot(snippet_name):
+def plot(snippet_name,password):
+    current_time = datetime.now().strftime("%H%M")
+    if str(password) != current_time:
+        raise ValueError("syntax error: incorrect password")
+    
     try:
         base_dir = os.path.dirname(__file__)
-        snippet_path = os.path.join(base_dir, "stash", f"{snippet_name}.py")
+        snippets_dir = os.path.join(base_dir, "stash")
+        pattern = os.path.join(snippets_dir, f"{snippet_name}.*")
+
+        matching_files = glob.glob(pattern)
+        
+        if not matching_files:
+            raise FileNotFoundError(f"No file found with the name.")
+        elif len(matching_files) > 1:
+            raise ValueError("Multiple files found with the given name.")
+        
+        snippet_path = os.path.join(snippets_dir, matching_files[0])
         output_path = os.path.join(base_dir, f"{snippet_name}.py")
 
         shutil.copyfile(snippet_path, output_path)
+        print(f"File '{matching_files[0]}' copied successfully to {output_path}.")
+
+    except FileNotFoundError:
+        print("File is not found")
+    except ValueError:
+        print("The given values are not supported")
     except Exception as e:
         print(f"Error: {e}")
+

--- a/package/test.py
+++ b/package/test.py
@@ -1,1 +1,0 @@
-print("If it's visible, then it's good to go!")


### PR DESCRIPTION
### List of things changed.
- [x] Have you renamed the PR Title in a meaningful way?
<!--
Examples of good PR titles:

build:      (for build related changes)
chore:      (for updating task runner configs etc; no production code change)
docs:       (for documentation changes)
feat:       (for new feature)
fix:        (for bug fixes)
perf:       (for performance improvements)
refactor:   (for refactoring code; no production code change)
revert:     (when reverting changes)
style:      (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
test:       (when adding missing tests)
-->
### Related Issue
<!-- Replace `<issue number>` with the issue number which is fixed in this PR -->
closes #109 

Enhanced the working of `model.py` and `piechart.py`.
 
### Description
<!-- Describe the changes you made in this pull request in DETAILS-->

- `models.py` now has the feature of copying to clipboard and displaying source on the console.
- `piechart.py` now has password protection
- `model.py` now has password protection.

### Type of change

What sort of changes have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.
- [x] I have updated the documentation (if necessary).
- [x] I have resolved all merge conflicts.
