### PR TITLE
Allow Output File Extension to Match Input File Extension

### DIFF
--- a/package/write.py
+++ b/package/write.py
@@ -20,8 +20,9 @@ def plot(snippet_name,password):
         elif len(matching_files) > 1:
             raise ValueError("Multiple files found with the given name.")
         
-        snippet_path = os.path.join(snippets_dir, matching_files[0])
-        output_path = os.path.join(base_dir, f"{snippet_name}.py")
+        snippet_path = matching_files[0] 
+        snippet_extension = os.path.splitext(snippet_path)[1] 
+        output_path = os.path.join(base_dir, f"{snippet_name}{snippet_extension}")
 
         shutil.copyfile(snippet_path, output_path)
         print(f"File '{matching_files[0]}' copied successfully to {output_path}.")


### PR DESCRIPTION
#### Description:
This pull request modifies the `write.py` module to enhance its functionality by allowing the output file to have the same extension as the input file. Previously, the output file was hardcoded to always have a `.py` extension, which limited the versatility of the module. This change enables users to work with files of any extension, improving the overall usability of the code.

#### Changes Made:
- Removed the hardcoded `.py` extension for the output file.
- Added logic to extract the extension of the matched input file and use it for the output file.

#### Code Changes:
- Modified the following lines to dynamically set the output file extension based on the input file's extension:

  ```python
  snippet_path = matching_files[0]  # To get the full path of the matched file
  snippet_extension = os.path.splitext(snippet_path)[1]  # Extract the extension from the file
  output_path = os.path.join(base_dir, f"{snippet_name}{snippet_extension}")  # Use the extracted extension

#### Benefits:
-Increased Flexibility: Users can now copy files of various types without losing their original format.
-Improved User Experience: This change simplifies file management for users who need to work with different file types.

