### PR TITLE
Added test cases for offline functions

### DIFF
--- a/package/offline/clip.py
+++ b/package/offline/clip.py
@@ -1,6 +1,6 @@
 import os
-from package.offline.support import copy_to_clipboard
-from package.offline.support import display
+from package.offline.support.copy_to_clipboard import copy_to_clipboard
+from package.offline.support.display import display
 
 
 def clip(snippet_name, password):

--- a/package/offline/support/display.py
+++ b/package/offline/support/display.py
@@ -1,5 +1,5 @@
 import os
-from package.offline.support import copy_to_clipboard
+from package.offline.support.copy_to_clipboard import copy_to_clipboard
 from package.password import valid_password
 
 

--- a/package/stash/test.py
+++ b/package/stash/test.py
@@ -1,1 +1,0 @@
-print("If it's visible, then it's good to go!")

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,27 +1,14 @@
+import os
 import pytest
-from package.clip import display
-from datetime import datetime
-import subprocess
-from package.clip import copy_to_clipboard
+from unittest.mock import patch, mock_open
+from package.offline.support import display
+from package.offline.clip import clip
+from package.password import valid_password
 
 
-def test_display_right_password():
-    current_time = datetime.now().strftime("%H%M")
-    assert display("test", current_time) is None
+def test_clip_invalid_password():
+    snippet_name = "test_snippet.txt"
+    password = "invalid_password" 
 
-
-def test_display_wrong_password():
-    with pytest.raises(ValueError, match="Invalid password"):
-        display("test", 1111)
-
-
-def test_copy_to_clipboard(monkeypatch):
-    def mock_run(*args, **kwargs):
-        pass
-
-    monkeypatch.setattr(subprocess, "run", mock_run)
-
-    try:
-        copy_to_clipboard("Whatever test")
-    except Exception:
-        pytest.fail("Unexpected error raised: {e}")
+    with pytest.raises(ValueError, match="Incorrect password"):
+        clip(snippet_name, password)

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,47 +1,60 @@
 import pytest
-import sys
-from datetime import datetime
-from package.show import display, copy_to_clipboard
+import os
+from unittest.mock import Mock, mock_open, patch
+from package.offline.show import show
+from package.offline.support.display import display
+
+@pytest.fixture
+def setup_test_env(monkeypatch):
+    base_dir = os.path.dirname(__file__)
+    snippets_dir = os.path.join(base_dir, "stash")
+    test_snippet = "test_content"
+    
+    mock_list = Mock()
+    mock_clipboard = Mock()
+    monkeypatch.setattr("package.offline.support.list_snippets", mock_list)
+    monkeypatch.setattr("package.offline.support.copy_to_clipboard", mock_clipboard)
+    
+    mock_dt = Mock()
+    mock_dt.now.return_value.strftime.return_value = "1430"
+    monkeypatch.setattr("package.password.datetime", mock_dt)
+    
+    return {
+        "base_dir": base_dir,
+        "snippets_dir": snippets_dir,
+        "mock_list": mock_list,
+        "mock_clipboard": mock_clipboard,
+        "test_snippet": test_snippet
+    }
+
+def test_display_invalid_password_type(setup_test_env):
+    with pytest.raises(ValueError):
+        display("test.txt", "1430", "display")
+
+def test_display_invalid_password_value(setup_test_env):
+    with pytest.raises(ValueError):
+        display("test.txt", 1431, "display")
+
+def test_display_file_not_found(setup_test_env):
+    with patch("builtins.open", mock_open()) as mock_file:
+        mock_file.side_effect = FileNotFoundError()
+        display("nonexistent.txt", 1430, "display")
+
+def test_display_action_display(setup_test_env):
+    env = setup_test_env
+    mock_file = mock_open(read_data=env["test_snippet"])
+    
+    with patch("builtins.open", mock_file), \
+         patch("builtins.print") as mock_print:
+        display("test.txt", 1430, "display")
+        
+        mock_print.assert_called_once_with(env["test_snippet"])
 
 
-# Mock datetime class
-class MockDateTime(datetime):
-    @classmethod
-    def now(cls):
-        return datetime.strptime("1234", "%H%M")  # Mock time to 12:34
-
-
-# Mock functions for clipboard operations
-def mock_subprocess_run(*args, **kwargs):
-    return None  # Assume successful run
-
-
-def mock_open_file_content(*args, **kwargs):
-    class MockFile:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            pass
-
-        def read(self):
-            return "Sample content"
-
-    return MockFile()
-
-
-def test_display_incorrect_password(monkeypatch):
-    monkeypatch.setattr("package.show.datetime", MockDateTime)  # Mock datetime
-
-    snippet_name = "test"
-    incorrect_password = "1111"  # Different from "1234"
-
-    with pytest.raises(ValueError, match="syntax error: incorrect password"):
-        display(snippet_name, incorrect_password)
-
-
-def test_copy_to_clipboard_unsupported_os(monkeypatch):
-    monkeypatch.setattr(sys, "platform", "unsupported_os")
-
-    with pytest.raises(OSError, match="Unsupported operating system"):
-        copy_to_clipboard("test content")
+def test_display_general_error(setup_test_env):
+    with patch("builtins.open", mock_open()) as mock_file, \
+         patch("builtins.print") as mock_print:
+        mock_file.side_effect = Exception("Test error")
+        display("test.txt", 1430, "display")
+        
+        mock_print.assert_called_once_with("Error: Test error")

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,67 +1,55 @@
+import pytest
+import os
 import shutil
-import glob
 from datetime import datetime
-from package.write import plot
+from unittest.mock import Mock
+from package.offline.write import write
 
+@pytest.fixture
+def setup_test_env():
+    base_dir = os.path.dirname(__file__)
+    snippets_dir = os.path.join(base_dir, "stash")
+    os.makedirs(snippets_dir, exist_ok=True)
+    
+    test_file = "test_snippet.txt"
+    test_content = "Test content"
+    with open(os.path.join(snippets_dir, test_file), 'w') as f:
+        f.write(test_content)
+        
+    yield base_dir, snippets_dir, test_file, test_content
+    
+    if os.path.exists(snippets_dir):
+        shutil.rmtree(snippets_dir)
+    if os.path.exists(os.path.join(base_dir, test_file)):
+        os.remove(os.path.join(base_dir, test_file))
 
-# we cannot mock this function, so mocking the whole class
-class MockDateTime(datetime):
-    @classmethod
-    def now(cls):
-        return datetime.strptime("1234", "%H%M")
+@pytest.fixture
+def mock_time(monkeypatch):
+    mock_dt = Mock()
+    mock_dt.now.return_value.strftime.return_value = "1430"
+    monkeypatch.setattr("package.password.datetime", mock_dt)
+    return mock_dt
 
+def test_invalid_password_type(setup_test_env, mock_time):
+    _, _, test_file, _ = setup_test_env
+    with pytest.raises(ValueError):
+        write(test_file, "1430")
 
-def mock_copyfile(src, dst):
-    pass
+def test_invalid_password_value(setup_test_env, mock_time):
+    _, _, test_file, _ = setup_test_env
+    
+    with pytest.raises(ValueError):
+        write(test_file, 1431)
 
+def test_nonexistent_file(setup_test_env, mock_time):
+    base_dir, _, _, _ = setup_test_env
+    
+    write("nonexistent.txt", 1430)
+    assert not os.path.exists(os.path.join(base_dir, "nonexistent.txt"))
 
-def mock_glob_single(pattern):
-    return ["stash/test.py"]
-
-
-def mock_glob_none(pattern):
-    return []
-
-
-def mock_glob_multiple(pattern):
-    return ["stash/test.py", "stash/test2.py"]
-
-
-def test_plot_success(monkeypatch, capfd):
-    monkeypatch.setattr("package.write.datetime", MockDateTime)
-    monkeypatch.setattr(shutil, "copyfile", mock_copyfile)
-    monkeypatch.setattr(glob, "glob", mock_glob_single)
-
-    snippet_name = "test"
-    password = "1234"
-    plot(snippet_name, password)
-
-    # Verify output
-    captured = capfd.readouterr()
-    assert "File 'stash/test.py' copied successfully" in captured.out
-
-
-def test_plot_no_file_found(monkeypatch, capfd):
-    monkeypatch.setattr("package.write.datetime", MockDateTime)
-    monkeypatch.setattr(glob, "glob", mock_glob_none)
-
-    snippet_name = "nonexistent"
-    password = "1234"
-    plot(snippet_name, password)
-
-    # Verify output
-    captured = capfd.readouterr()
-    assert "File is not found" in captured.out
-
-
-def test_plot_multiple_files_found(monkeypatch, capfd):
-    monkeypatch.setattr("package.write.datetime", MockDateTime)
-    monkeypatch.setattr(glob, "glob", mock_glob_multiple)
-
-    snippet_name = "test"
-    password = "1234"
-    plot(snippet_name, password)
-
-    # Verify output
-    captured = capfd.readouterr()
-    assert "The given values are not supported" in captured.out
+def test_copy_permission_error(setup_test_env, mock_time, monkeypatch):
+    base_dir, _, test_file, _ = setup_test_env
+    monkeypatch.setattr("shutil.copyfile", lambda x, y: exec('raise PermissionError("Permission denied")'))
+    
+    write(test_file, 1430)
+    assert not os.path.exists(os.path.join(base_dir, test_file))


### PR DESCRIPTION
# Test: written test cases for offline functions

closes #199 

## Changes made

changes are made only in test cases, but a few file imports have been fixed to resolve the `no importable module found error`.

## Screenshots

![Screenshot 2024-11-09 132810](https://github.com/user-attachments/assets/8e30b61e-51b3-42fe-8329-213eb9527f5c)

> *note* clip.py has only 1 test case of password, because rest of the test cases are covered in display tests.